### PR TITLE
fix: Class 'Option' should have [public, protected] no-arg constructor

### DIFF
--- a/src/main/java/com/myshop/catalog/command/domain/product/Option.java
+++ b/src/main/java/com/myshop/catalog/command/domain/product/Option.java
@@ -10,7 +10,7 @@ public class Option {
     @Column(name = "option_title")
     private String title;
 
-    private Option() {
+    protected Option() {
     }
 
     public Option(String value, String title) {


### PR DESCRIPTION
JPA 엔티티는 접근제한자가 `public` 혹은 `protected`인 매개변수 없는 생성자를 가져야 하지만, `private`으로 설정돼있었음